### PR TITLE
Ubuntu compilation fixes

### DIFF
--- a/src/game/skills/SkillSet.h
+++ b/src/game/skills/SkillSet.h
@@ -64,6 +64,11 @@ public:
   class iterator //: public /*std::iterator<std::forward_iterator_tag, Skill>/*, std::iterator_traits<iterator<Skill>>,*/
   {
   public:
+    using difference_type = ptrdiff_t;
+    using value_type = Skill*;
+    using reference = const Skill&;
+    using pointer = const Skill*;
+    using iterator_category = std::random_access_iterator_tag;
 
     iterator(const SkillSet& parent, s16 current = 0) : parent(&parent), current(current), size(parent.size()) { }
     iterator(const iterator<Skill> &other) = default;
@@ -79,17 +84,15 @@ public:
     iterator<Skill> operator++(int) { auto tmp(*this); ++current; return tmp; }
     iterator<Skill> operator--(int) { auto tmp(*this); --current; return tmp; }
     
+    difference_type operator-(const iterator<Skill>& other) const { return current - other.current; }
+    
 //    iterator<Skill>(const s16& offset) { auto old = current; current += offset; auto tmp(*this); current = old; return tmp; }
 
     Skill operator*() { return parent->get(current); }
     const Skill operator*() const { return parent->get(current); }
     //const Skill* operator->() { return parent.get(current); }
     
-    using difference_type = ptrdiff_t;
-    using value_type = Skill*;
-    using reference = const Skill&;
-    using pointer = const Skill*;
-    using iterator_category = std::random_access_iterator_tag;
+
     
     protected:
       const SkillSet* parent;

--- a/src/game/world/Tile.h
+++ b/src/game/world/Tile.h
@@ -8,6 +8,7 @@
 #include "common/Util.h"
 
 #include <list>
+#include <memory>
 
 class World;
 class City;

--- a/src/gfx/Font.cpp
+++ b/src/gfx/Font.cpp
@@ -11,6 +11,8 @@
 #include "Gfx.h"
 #include "common/mystrings.h"
 
+#include <memory>
+
 using namespace std;
 
 

--- a/src/platform/Path.h
+++ b/src/platform/Path.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstring>
 #include <cerrno>
 #include <cassert>
 #include <memory>

--- a/src/save/OriginalSave.h
+++ b/src/save/OriginalSave.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <type_traits>
 #include <array>
+#include <memory>
 
 #include "common/Common.h"
 

--- a/src/ui/Buttons.h
+++ b/src/ui/Buttons.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <functional>
 #include <vector>
+#include <memory>
 
 class FontSpriteSheet;
 

--- a/src/ui/parts/DrawQueue.h
+++ b/src/ui/parts/DrawQueue.h
@@ -3,6 +3,7 @@
 #include "common/Common.h"
 
 #include <vector>
+#include <memory>
 
 template<typename T, typename S> class DrawElement;
 


### PR DESCRIPTION
This PR fixes an issue with `SkillSet::iterator` and adds missing includes for compilation on Ubuntu (tested on clang-3.8).

The executable still fails to link but at least now each translation unit is compiled.